### PR TITLE
Add project: Matcha

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1589,6 +1589,10 @@ projects:
 - name: G-SchNet
   category: generative
   github_id: atomistic-machine-learning/G-SchNet
+- name: Matcha
+  category: generative
+  labels: ["drug-discovery", "cheminformatics", "rep-learn", "benchmarking"]
+  github_id: LigandPro/Matcha
 - name: SchNOrb
   category: ml-wft
   github_id: atomistic-machine-learning/SchNOrb


### PR DESCRIPTION
## Summary
- Add Matcha to `projects.yaml` as a generative atomistic ML project for drug discovery and docking.
- Label it with drug-discovery, cheminformatics, representation learning, and benchmarking metadata.

## Validation
- Ran `git diff --check`.
- Parsed `projects.yaml` with Ruby YAML and confirmed the Matcha entry is present.

Note: I only changed `projects.yaml`, following the contribution guidelines.