### PR TITLE
ci: close stale auto-update PRs before creating a new one

### DIFF
--- a/.github/workflows/update-best-of-list.yml
+++ b/.github/workflows/update-best-of-list.yml
@@ -26,6 +26,19 @@ jobs:
         name: set-version-via-date
         run: echo "VERSION=$(date '+%Y.%m.%d')" >> $GITHUB_ENV
       - uses: actions/checkout@v4
+      - name: close-stale-update-prs
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Older auto-update PRs are always superseded by this run (README.md /
+          # latest-changes.md are fully regenerated), so close them to prevent the
+          # pile-up that causes merge conflicts when merged out of order.
+          gh pr list --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("${{ env.BRANCH_PREFIX }}")) | .number' \
+          | while read -r pr; do
+              gh pr close "$pr" --delete-branch --comment "Superseded by a newer best-of update." || true
+            done
       - name: check-version-tag
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

The weekly `update-best-of-list` workflow opens a PR that **regenerates** `README.md` and `latest-changes.md` (and adds dated `history/` files). These generated files are committed. When several such PRs pile up and are merged out of order, the pending ones — branched off an older `main` — have rewritten the same lines and hit merge conflicts in `README.md`/`latest-changes.md`. `projects.yaml` (the real source) is never touched by these runs, so an older auto-PR is always superseded by a newer one.

## Fix

Add a `close-stale-update-prs` step that closes any open `update/*` PRs before this run creates its own. Guarantees exactly one auto-update PR exists at a time, so the pile-up (and the conflicts) can't happen. The manual merge click is unchanged.

Scoped to `update/` (BRANCH_PREFIX) branches only — never touches human PRs. Runs before this run's branch/PR exists, so it only closes prior ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)