### PR TITLE
Fix silent GitHub GraphQL outage in update-best-of-list

### DIFF
--- a/.github/workflows/update-best-of-list.yml
+++ b/.github/workflows/update-best-of-list.yml
@@ -57,25 +57,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # TEMPORARY - delete once the GraphQL token question is settled (see PR description).
-      # Since the 2026-07-23 run, every GitHub GraphQL query returned no repository data while
-      # the REST calls kept working. best-of 0.8.5 swallows that silently, so this prints the
-      # raw response for both tokens to show which one GitHub still answers.
-      - name: debug-graphql-token
-        shell: bash
-        env:
-          DEFAULT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PAT_TOKEN: ${{ secrets.GH_API_TOKEN }}
-        run: |
-          for name in DEFAULT_TOKEN PAT_TOKEN; do
-            token="${!name}"
-            echo "=== $name ==="
-            if [ -z "$token" ]; then echo "(not set)"; continue; fi
-            curl -sS -w '\nHTTP %{http_code}\n' \
-              -H "Authorization: token $token" \
-              -d '{"query":"{repository(owner:\"andreagrisafi\",name:\"SALTED\"){url stargazers{totalCount}}}"}' \
-              https://api.github.com/graphql
-          done
       - name: update-best-of-list
         # original action, last update, release v0.8.5 on Jan 11, 2022
         uses: best-of-lists/best-of-update-action@v0.8.5

--- a/.github/workflows/update-best-of-list.yml
+++ b/.github/workflows/update-best-of-list.yml
@@ -81,7 +81,13 @@ jobs:
           # this guards against is a *total* GraphQL outage, which ran green for three weeks.
           # commit_count is the sentinel because only the GraphQL query sets it - there is no
           # libraries.io fallback, so it drops to ~0 the moment GraphQL stops answering.
-          path = sorted(glob.glob("history/*_projects.csv"))[-1]
+          files = sorted(glob.glob("history/*_projects.csv"))
+          if not files:
+              sys.exit("No history/*_projects.csv was written - generation did not complete.")
+
+          # ponytail: newest-by-filename, so this cannot tell a stale CSV from a fresh one.
+          # Fine here - the generator step fails the job by itself if it does not finish.
+          path = files[-1]
           rows = [r for r in csv.DictReader(open(path)) if r["github_id"]]
           filled = sum(1 for r in rows if r["commit_count"])
           print(f"{path}: {filled}/{len(rows)} GitHub projects have commit_count")

--- a/.github/workflows/update-best-of-list.yml
+++ b/.github/workflows/update-best-of-list.yml
@@ -57,6 +57,25 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # TEMPORARY - delete once the GraphQL token question is settled (see PR description).
+      # Since the 2026-07-23 run, every GitHub GraphQL query returned no repository data while
+      # the REST calls kept working. best-of 0.8.5 swallows that silently, so this prints the
+      # raw response for both tokens to show which one GitHub still answers.
+      - name: debug-graphql-token
+        shell: bash
+        env:
+          DEFAULT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT_TOKEN: ${{ secrets.GH_API_TOKEN }}
+        run: |
+          for name in DEFAULT_TOKEN PAT_TOKEN; do
+            token="${!name}"
+            echo "=== $name ==="
+            if [ -z "$token" ]; then echo "(not set)"; continue; fi
+            curl -sS -w '\nHTTP %{http_code}\n' \
+              -H "Authorization: token $token" \
+              -d '{"query":"{repository(owner:\"andreagrisafi\",name:\"SALTED\"){url stargazers{totalCount}}}"}' \
+              https://api.github.com/graphql
+          done
       - name: update-best-of-list
         # original action, last update, release v0.8.5 on Jan 11, 2022
         uses: best-of-lists/best-of-update-action@v0.8.5
@@ -66,7 +85,28 @@ jobs:
         # uses: Irratzo/best-of-lists_best-of-update-action@v0.1.1
         with:
           libraries_key: ${{ secrets.LIBRARIES_KEY }}
-          github_key: ${{ secrets.GITHUB_TOKEN }}
+          # NOT secrets.GITHUB_TOKEN: the Actions token can no longer resolve *other*
+          # repositories through the GitHub GraphQL API, which is where the generator gets
+          # descriptions, homepages, stars, issue and commit counts. GH_API_TOKEN is a classic
+          # PAT with no scopes (public-repo read is all that is needed).
+          github_key: ${{ secrets.GH_API_TOKEN }}
+      - name: check-generation-sanity
+        shell: bash
+        run: |
+          python3 - <<'EOF'
+          import csv, glob, sys
+
+          # Absolute fill-rate floor rather than a diff against the previous run: the failure
+          # this guards against is a *total* GraphQL outage, which ran green for three weeks.
+          # commit_count is the sentinel because only the GraphQL query sets it - there is no
+          # libraries.io fallback, so it drops to ~0 the moment GraphQL stops answering.
+          path = sorted(glob.glob("history/*_projects.csv"))[-1]
+          rows = [r for r in csv.DictReader(open(path)) if r["github_id"]]
+          filled = sum(1 for r in rows if r["commit_count"])
+          print(f"{path}: {filled}/{len(rows)} GitHub projects have commit_count")
+          if filled < 0.5 * len(rows):
+              sys.exit("GitHub GraphQL metadata fetch looks broken - refusing to publish.")
+          EOF
       - name: push-update
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/projects.yaml
+++ b/projects.yaml
@@ -1715,7 +1715,6 @@ projects:
   github_id: dilkins/TENSOAP
 - name: SALTED
   category: ml-dft
-  description: Symmetry-Adapted Learning of Three-dimensional Electron Densities (and their electrostatic response)
   github_id: andreagrisafi/SALTED
 - name: Compositionally-Restricted Attention-Based Network (CrabNet)
   category: rep-learn


### PR DESCRIPTION


---

## Confirmed

Run [31320854252](https://github.com/JuDFTteam/best-of-atomistic-machine-learning/actions/runs/31320854252), same query, same moment, two tokens:

```
=== GITHUB_TOKEN ===                                     HTTP 200
{"data":{"repository":null},"errors":[{"type":"FORBIDDEN",
 "path":["repository","stargazers"],
 "message":"Resource not accessible by integration"}]}

=== GH_API_TOKEN (PAT) ===                               HTTP 200
{"data":{"repository":{"url":"https://github.com/andreagrisafi/SALTED",
 "stargazers":{"totalCount":45}}}}
```

The denial is on the **`stargazers`** field rather than the repository itself. That field is non-nullable in GitHub's schema, so the null propagates up and takes the whole `repository` object with it — which is why the outage was total rather than partial, and why nothing was logged.

### Data restored

| metric | 07-19 (last good) | 08-09 (broken) | this run |
|---|---|---|---|
| `commit_count` | 456 | 1 | **456** |
| `closed_issue_count` | 340 | 7 | **340** |
| `github_url` | 457 | 390 | **457** |
| `star_count` | 468 | 407 | **468** |
| `show == True` | 242 | 174 | **239** |
| no homepage | 1 | 52 | **1** |

`show == True` lands at 239 rather than 242 — three weeks of ordinary drift, not a regression.

SALTED: `homepage` restored, `show=True`, projectrank 1 → **14**, ⭐ 45.

MACE, before and after:

```
broken:   (🥈14 · ⭐ 1.2K) … - [GitHub](…) (👨‍💻 77 · 🔀 420):
this run: (🥇24 · ⭐ 1.3K) … - [GitHub](…) (👨‍💻 77 · 🔀 440 · 📋 660 - 27% open · ⏱️ 07.08.2026):
```

`check-generation-sanity` passed at 456/459. The regenerated list is in #584.
